### PR TITLE
Acid transactions for db operations

### DIFF
--- a/backend/src/database/canned_queries/mod.rs
+++ b/backend/src/database/canned_queries/mod.rs
@@ -1,0 +1,1 @@
+pub mod post_queries;

--- a/backend/src/database/canned_queries/post_queries.rs
+++ b/backend/src/database/canned_queries/post_queries.rs
@@ -19,5 +19,6 @@ pub async fn apply_post_deletion_operations(post: Post) -> Result<String, AppErr
     let query_to_remove_post = sqlx::query(Post::delete_by_id_sql()).bind(post.id);
     query_to_remove_post.execute(&mut *transaction).await?;
 
+    transaction.commit().await?;
     Ok(format!("Removed post: {:?}, removed comments: {:?}, and removed image: {:?}", post.id, post.comments, post.image))
 }

--- a/backend/src/database/canned_queries/post_queries.rs
+++ b/backend/src/database/canned_queries/post_queries.rs
@@ -1,0 +1,23 @@
+use my_sqlx_crud::traits::Schema;
+
+use crate::{database::{types::{post::Post, comment::Comment, image::Image}, sql_helpers::get_pool}, socket_handlers::types::AppError};
+
+pub async fn apply_post_deletion_operations(post: Post) -> Result<String, AppError> {
+    let pool = get_pool().await;
+    let mut transaction = pool.begin().await?;
+
+    // TODO: replace these loops with something more optimized (query_builder probably)
+    // so that we don't make a billion sql queries and instead do all if it in one.
+    for comment_id in &post.comments {
+        let query_to_remove_comment = sqlx::query(Comment::delete_by_id_sql()).bind(comment_id);
+        query_to_remove_comment.execute(&mut *transaction).await?;
+    }
+
+    let query_to_remove_image = sqlx::query(Image::delete_by_id_sql()).bind(post.image);
+    query_to_remove_image.execute(&mut *transaction).await?;
+
+    let query_to_remove_post = sqlx::query(Post::delete_by_id_sql()).bind(post.id);
+    query_to_remove_post.execute(&mut *transaction).await?;
+
+    Ok(format!("Removed post: {:?}, removed comments: {:?}, and removed image: {:?}", post.id, post.comments, post.image))
+}

--- a/backend/src/database/canned_queries/what_are_those.md
+++ b/backend/src/database/canned_queries/what_are_those.md
@@ -1,0 +1,39 @@
+# Canned queries for the backend
+
+### What is a canned query?
+This directory contains canned queries. A canned query is a fixed SQL procedure/query with a few variables.
+
+The queries in this directory are intended for use with our structs representing posts, images, and so on. 
+
+Oversimplified example:
+
+```Rust
+let result = post_queries::apply_deletion_operations(post_id, &pool);
+```
+
+In this example, the canned query is deleting a post. Upon post deletion, we must check that the post,
+image, and comments tied to the post are also deleted. The `apply_deletion_operations(...)` thus makes
+method calls to `Comment::delete()`, `Post::delete()`, and `Image::delete()`.
+
+### ACID properties
+The ACID properties are properties that make sure the data in a database is valid, i.e. not "fucked". An 
+example of fuckedness is if an image exists without a post containing it. Another is if there are comments
+on a post, dated before the post's creation date.
+
+These canned queries have the responsibility of ensuring these ACID properties are present. Thus, if you
+begin making calls outside of these canned queries, you are no longer guaranteed that the database is valid.
+
+ACID is atomicity, consistency, isolation, and durability. The ACID properties are already enforced
+by the PostgreSQL database.
+
+However, if we consider deleting a post and all its comments, images, etc. as a 
+transaction, then, without our canned queries, we do not have atomicity yet. This is because we are simply 
+calling `delete()` etc. on our tables individually, meaning we might end up deleting the post successfully,
+but getting an error when deleting the comments tied to the post. I.e. we have completed part of our transaction,
+but not all. This will then fuck up our database.
+
+In the same way, sure, the database without these canned queries is consistent in some way. But we would like
+to keep a couple of new invariants, i.e. all comments must have a post, and so on. Thus, in order for the database
+to remain consistent w.r.t. these new invariants, we must enforce it in our own way. To see why, consider the 
+same example as above. We would not have a consistent database anymore. This is because at this point, our rule 
+"all comments must be tied to a post" is now violated. So in order to enforce our new rules, we use these canned queries.

--- a/backend/src/database/comment_controller.rs
+++ b/backend/src/database/comment_controller.rs
@@ -64,7 +64,7 @@ pub async fn create_comment(
             return match comment.delete(&pool).await {
                 Ok(_) => Err(error),
                 Err(inner_error) => {
-                    println!("{}. Failed when updating comment array on Post {}. Tried reverting creation of comment {}, but that operation failed.", inner_error, post_id, comment_id);
+                    println!("{}. Failed when updating comment array on Post {:?}. Tried reverting creation of comment {:?}, but that operation failed.", inner_error, post_id, comment_id);
                     Err(error)
                 }
             }

--- a/backend/src/database/mod.rs
+++ b/backend/src/database/mod.rs
@@ -5,3 +5,4 @@ pub mod post_controller;
 pub mod sql_helpers;
 pub mod types;
 pub mod user_controller;
+pub mod canned_queries;

--- a/backend/src/database/types/comment.rs
+++ b/backend/src/database/types/comment.rs
@@ -7,14 +7,17 @@ use my_sqlx_crud::traits::Schema;
 use sqlx::Pool;
 use sqlx::Postgres;
 
+type CommentId = i32;
+
 #[derive(Serialize, Deserialize, Clone, Debug, sqlx::FromRow, SqlxCrud, PartialEq)]
 #[database(Postgres)]
 pub struct Comment {
-    pub id: i32,
+    pub id: CommentId,
     pub poster_id: i32,
     pub timestamp: i64,
     pub data: String,
 }
+
 impl Comment {
     pub async fn by_id(pool: &Pool<Postgres>, id: i32) -> Result<Option<Comment>, AppError> {
         let query = format!("select * from {} where id = {}", Self::table_name(), id);

--- a/backend/src/database/types/image.rs
+++ b/backend/src/database/types/image.rs
@@ -1,18 +1,19 @@
-use my_sqlx_crud::traits::Schema;
 use my_sqlx_crud_macro::SqlxCrud;
 use serde::{Deserialize, Serialize};
-use sqlx::{FromRow, Pool, Postgres};
+use sqlx::prelude::FromRow;
 
 use crate::database::helpers::get_timestamp;
-use crate::socket_handlers::types::AppError;
+
+type ImageId = i32;
 
 #[derive(Clone, Debug, Serialize, Deserialize, FromRow, SqlxCrud, PartialEq)]
 #[database(Postgres)]
 pub struct Image {
-    pub id: i32,
+    pub id: ImageId,
     pub timestamp: i64,
     pub data: Vec<u8>,
 }
+
 impl Image {
     pub fn random() -> Self {
         Image {

--- a/backend/src/database/types/post.rs
+++ b/backend/src/database/types/post.rs
@@ -3,10 +3,13 @@ use my_sqlx_crud::traits::Schema;
 use my_sqlx_crud_macro::SqlxCrud;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, Pool, Postgres};
+
+type PostId = i32;
+
 #[derive(Clone, Debug, Serialize, Deserialize, FromRow, SqlxCrud, PartialEq)]
 #[database(Postgres)]
 pub struct Post {
-    pub id: i32,
+    pub id: PostId,
     pub poster_id: i32,
     pub image: i32,
     pub comments: Vec<i32>,

--- a/backend/src/database/types/user.rs
+++ b/backend/src/database/types/user.rs
@@ -1,14 +1,14 @@
-use my_sqlx_crud::traits::Schema;
 use my_sqlx_crud_macro::SqlxCrud;
-use sqlx::Postgres;
-use sqlx::{prelude::FromRow, Pool};
+use sqlx::prelude::FromRow;
 
 use crate::database::helpers::get_timestamp;
-use crate::socket_handlers::types::AppError;
+
+type UserId = i32;
+
 #[derive(Clone, Debug, FromRow, SqlxCrud, PartialEq)]
 #[database(Postgres)]
 pub struct User {
-    pub id: i32,
+    pub id: UserId,
     pub friends: Vec<i32>,
     pub timestamp: i64,
 }


### PR DESCRIPTION
Make ACID transactions out of multiple, smaller transactions. These are in the canned_queries directory.